### PR TITLE
Fix Binder error & Almond update

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -5,7 +5,7 @@ set -e
 curl -fLo cs https://github.com/coursier/coursier/releases/download/v2.0.3/cs-x86_64-pc-linux
 chmod +x cs
 
-ALMOND_VERSION=0.10.9
+ALMOND_VERSION=0.11.1
 
 # Install almond for Scala 2.12
 ./cs launch "almond:$ALMOND_VERSION" --scala 2.12.12 -- \

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,0 +1,3 @@
+nbdime
+jupyterlab-git
+jupyterlab~=2.0


### PR DESCRIPTION
Update Almond up to 0.11.1 and use JupyterLab v2 for scalafmt compatibility